### PR TITLE
#165735960 API endpoint for user to get repayment loans 

### DIFF
--- a/server/api-routes/user-routes.js
+++ b/server/api-routes/user-routes.js
@@ -10,16 +10,19 @@ router.post('/auth/signup', userHandler.signupHandler);
 // Make post requests to signin API Endpoints
 router.post('/auth/signin', userHandler.signinHandler);
 // Make post request to verify user
-router.patch('/users/:email/verify', Auth.userAuthorize, userHandler.getVerified);
+router.patch('/users/:email/verify', Auth.adminAuthorize, userHandler.getVerified);
 // Admin Get specific loan
 router.get('/loans/:id', Auth.userAuthorize, adminHandler.getSpecificLoan);
 
 /** This route will handle admin getting all loan and
- *  Admin getting current loans in the case where query params {status:approved & repaid:false} 
+ *  Admin getting current loans in the case where query params {status:approved & repaid:false}
  * (GET /loans?status=approved&repaid=false)
  *  Also repaid loans in the case where {status:approved & repaid:true} is passed as query params
  * (GET /loans?status=approved&repaid=true)
  */
-router.get('/loans', Auth.userAuthorize, adminHandler.getCurrentLoans);
+router.get('/loans', Auth.adminAuthorize, adminHandler.getCurrentLoans);
+
+// Get request to user repayment loan history
+router.get('/loans/:id/repayments', Auth.userAuthorize, userHandler.getRepaymentLoans);
 
 module.exports = router;

--- a/server/authentication/auth.js
+++ b/server/authentication/auth.js
@@ -19,10 +19,10 @@ class Authenticate {
     return bcryptjs.hashSync(password, 10);
   }
 
-  static userAuthorize(req, res, next) {
+  static adminAuthorize(req, res, next) {
     try {
-      const payload = req.headers.authorization.split(' ')[1];
-      req.user = Authenticate.verifyToken(payload);
+      const token = req.headers.authorization.split(' ')[1];
+      req.user = Authenticate.verifyToken(token);
       if (req.user.payload.email !== 'omoke@admin.com') {
         return res.status(401)
           .json({
@@ -36,6 +36,28 @@ class Authenticate {
         .json({
           status: 401,
           error: 'Invalid token!',
+        });
+    }
+  }
+
+  static userAuthorize(req, res, next) {
+    try {
+      const token = req.headers.authorization.split(' ')[1];
+      const decoded = Authenticate.verifyToken(token);
+      const userEmail = decoded.payload.email;
+      if (userEmail.endsWith('gmail.com')) {
+        return res.status(403)
+          .json({
+            status: 403,
+            error: 'Unauthorized access',
+          });
+      }
+      return next();
+    } catch (error) {
+      return res.status(401)
+        .json({
+          status: 401,
+          error: 'Invalid token',
         });
     }
   }

--- a/server/controllers/userHandler.js
+++ b/server/controllers/userHandler.js
@@ -1,4 +1,5 @@
 import users from '../models/userDataStructure';
+import repayments from '../models/repaymentStructure';
 import Validate from '../middlewares/validation';
 import Authenticate from '../authentication/auth';
 
@@ -129,6 +130,24 @@ class userHandler {
           });
       }
     }
+  }
+
+  // User get repayment loans
+  static getRepaymentLoans(req, res) {
+    const { id } = req.params;
+    const repayment = repayments.filter(repLoan => repLoan.loanId === id);
+    if (repayment) {
+      return res.status(200)
+        .json({
+          status: 200,
+          data: repayment,
+        });
+    }
+    return res.status(404)
+      .json({
+        status: 404,
+        error: 'Repayment not found',
+      });
   }
 }
 

--- a/server/models/repaymentStructure.js
+++ b/server/models/repaymentStructure.js
@@ -1,0 +1,10 @@
+const repaymentStructure = [
+  {
+    id: '1',
+    createdOn: new Date(),
+    loanId: '123456789',
+    amount: 4500.50,
+  },
+];
+
+export default repaymentStructure;


### PR DESCRIPTION
## What does this PR do?
This pull request adds the api endpoint that allows the user to make requests to loan repayment history
## Description of Task to be completed?
Having this api endpoint `api/v1/loans/:id/repayments` working
## How should this be manually tested?
+ Clone this repo
+ `cd` into directory
+ run `npm install` to add dependencies
+ run `npm start` to start server at port 4000
+ then test with postman
## Any background context you want to provide?
NIL
## What are the relevant pivotal tracker stories?
`ft-api-user-get-repayment-loans`
## Screenshots (if appropriate)
NIL
## Questions:
NIL